### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ documentation = "https://docs.rs/crate/k8s-cri"
 readme = "README.md"
 
 [dependencies]
-tonic = { version = "0.4", features = ['tls'] }
-prost = "0.7"
+tonic = { version = "0.5", features = ['tls'] }
+prost = "0.8"
 
 [build-dependencies.tonic-build]
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["prost", "transport"]
 
 [dev-dependencies]
-tokio = { version = "1.2", features = [ "rt-multi-thread" ] }
+tokio = { version = "1.11", features = [ "rt-multi-thread" ] }
 tower = "0.4"


### PR DESCRIPTION
Hello, thank you for creating k8s-cri! This PR updates the `tonic`, `tonic-build`, `prost`, and `tokio` dependencies to the latest released version of each.