### PR TITLE
github workflows: install protobuf compiler

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,10 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
prost 0.11 no longer bundles protoc, so explicit
installation is required

Signed-off-by: Eliad Peller <eliad.peller@wiz.io>